### PR TITLE
Muffingen edits to enable ENTS fields

### DIFF
--- a/BASECONFIG.16lvl.config
+++ b/BASECONFIG.16lvl.config
@@ -16,6 +16,7 @@ ma_flag_sedgem=.FALSE.
 ma_flag_rokgem=.FALSE.
 ma_flag_gemlite=.FALSE.
 ma_flag_ecogem=.FALSE.
+ma_flag_ents=.FALSE.
 # *******************************************************************
 
 # *******************************************************************

--- a/BASECONFIG.8lvl.config
+++ b/BASECONFIG.8lvl.config
@@ -16,6 +16,7 @@ ma_flag_sedgem=.FALSE.
 ma_flag_rokgem=.FALSE.
 ma_flag_gemlite=.FALSE.
 ma_flag_ecogem=.FALSE.
+ma_flag_ents=.FALSE.
 # *******************************************************************
 
 # *******************************************************************

--- a/EXAMPLE_BLANK.m
+++ b/EXAMPLE_BLANK.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_BLANK_deep.m
+++ b/EXAMPLE_BLANK_deep.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_GCMFOAM_modern.m
+++ b/EXAMPLE_GCMFOAM_modern.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=true;             % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_GCMHadCM3L_modern.m
+++ b/EXAMPLE_GCMHadCM3L_modern.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=true;             % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_K1_SEDGEMonly.m
+++ b/EXAMPLE_K1_SEDGEMonly.m
@@ -78,6 +78,7 @@ opt_makewind=false;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;        % [false/true] force zonal wind generation
 opt_makealbedo=false;           % [false/true] make albedo file
 opt_makeseds=true;              % [false/true] make sediment files
+opt_makeents=true;              % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_K1_permian.m
+++ b/EXAMPLE_K1_permian.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_K2_supercontinent.m
+++ b/EXAMPLE_K2_supercontinent.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_MASK_drakeworld.m
+++ b/EXAMPLE_MASK_drakeworld.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_MASK_eqpasworld.m
+++ b/EXAMPLE_MASK_eqpasworld.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_MASK_ridgeworld.m
+++ b/EXAMPLE_MASK_ridgeworld.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_MASK_waterworld.m
+++ b/EXAMPLE_MASK_waterworld.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=false;            % [false/true] make sediment files
+opt_makeents=false;            % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %

--- a/EXAMPLE_MAT_present_bathymetry.m
+++ b/EXAMPLE_MAT_present_bathymetry.m
@@ -78,6 +78,7 @@ opt_makewind=true;             % [false/true] re-grid wind products?
 opt_makezonalwind=false;       % [false/true] force zonal wind generation
 opt_makealbedo=true;           % [false/true] make albedo file
 opt_makeseds=true;            % [false/true] make sediment files
+opt_makeents=true;             % [false/true] create ENTS files?
 %
 % *** OPTIONS -- GRID FILTERING ***************************************** %
 %       

--- a/config_testents.m
+++ b/config_testents.m
@@ -1,0 +1,63 @@
+% *********************************************************************** %
+% *** USER SETTINGS ***************************************************** %
+% *********************************************************************** %
+%
+% PARAM NAME & DEFAULT VALUE   % [FORMAT] BRIEF DESCRIPTION
+%
+% *** EXPERIMENT INPUT AND OUTPUT *************************************** %
+%
+par_wor_name='testents';       % ['worxbowl'] 8-char (output) config name
+par_gcm='hadcm3';             % ['hadcm3l'] input format/GCM name
+par_expid='teiia';             % ['xbowl'] experiment name
+par_pathin='INPUT';   % ['EXAMPLES.INPUT'] path to input dir
+par_pathout='OUTPUT'; % ['EXAMPLES.OUTPUT'] path to output dir
+opt_outputdir=false;           % [false/true] ask for output directory?
+par_mask_mask_name='';
+%
+% *** GRID RESOLUTION & REGRIDDING CONTROLS ***************************** %
+%
+par_max_i=36;                  % [36] # grid cells in longitude dir (i)
+par_max_j=36;                  % [36] # grid cells in latitude  dir (j)
+par_max_k=16;                  % [36] # depth leves in ocean
+par_max_D=5000.0;              % [5000.0] max grid depth (m)
+par_lon_off=-180.0;            % [-180.0] longitude offset of grid start
+par_min_Dk=2;                  % [2] minimum ocean depth (as # levels)
+par_min_k=1;                   % [1] maximum ocean depth (k value)
+par_A_frac_threshold=0.45;     % [0.5] fractional area threshold for ocean
+opt_equalarea=true;            % [false/true] equal area grid?
+opt_highresseds=false;         % [false/true] create 2x res sediment grid
+par_runoffopt=0;               % [0/1] run-off generation option
+par_sedsopt=1;                 % [0/1/2] sediment re-gridding option
+par_tauopt=0;                  % [0/1/2] zonal windstress generation option
+par_age=55.0;                   % [0.0] optional age of paleo configuration
+%
+% *** OPTIONS -- MAIN *************************************************** %
+%
+opt_makeall=true;              % [false/true] apply all common options?
+opt_user=true;                 % [false/true] enable user input to grid
+opt_plots=false;                %
+%
+% *** OPTIONS -- OTHER ************************************************** %
+%
+opt_makemask=true;             % [false/true] re-grid mask?
+opt_maketopo=true;             % [false/true] re-grid bathymetry?
+opt_makeocean=true;            % [false/true] create ocean files?
+opt_makerunoff=true;           % [false/true] create runoff pattern?
+opt_makewind=true;             % [false/true] re-grid wind products?
+opt_makealbedo=true;           % [false/true] make albedo file
+opt_makeseds=true;             % [false/true] make sediment files
+opt_makeents=true;             %
+%
+% *** GRID FILTERING **************************************************** %
+%
+opt_filtermask=true;           % [false/true] filter land-sea mask?
+opt_filtertopo=true;           % [false/true] filter topography?
+opt_makepoleswide=true;        % [false/true] force wide polar island zone
+par_min_oceann=20;             % [20] minimum allowed lake size (# cells)
+%
+% *** ENVIRONMENT SETTINGS ********************************************** %
+%
+par_dpath_source='source';     % ['source'] relative path to muffingen code
+opt_debug=false;               % [false/true] debug output?
+%
+% *********************************************************************** %

--- a/muffingen.m
+++ b/muffingen.m
@@ -403,7 +403,7 @@ switch par_gcm
     case {'cesm'}
         if isempty(par_nc_topo_name),  par_nc_topo_name  = 'climo'; end
         if isempty(par_nc_mask_name),  par_nc_mask_name  = par_nc_topo_name; end
-        if isempty(par_nc_axes_name),  par_nc_axes_name  = par_nc_topo_name; endpar_wspeed_avstr
+        if isempty(par_nc_axes_name),  par_nc_axes_name  = par_nc_topo_name; end
         if isempty(par_nc_atmos_name), par_nc_atmos_name = par_nc_topo_name; end
         if isempty(par_nc_ocean_name), par_nc_ocean_name = par_nc_topo_name; end
         if isempty(par_nc_coupl_name), par_nc_coupl_name = par_nc_topo_name; end

--- a/muffingen.m
+++ b/muffingen.m
@@ -1384,17 +1384,19 @@ if opt_makeents
             print('-dpsc2', [[str_dirout '/' str_nameout] '.zonalalbd_cl.' str_date '.ps']);
             % reorientate albedo vector for saving
             vo_albd_cl = fliplr(vo_albd_cl);
-    end
-    fprint_1Dn(vo_albd_cl(:),[[str_dirout '/' str_nameout] '.albd_cl.dat'],'%8.4f','%8.4f',true,false);
-    fprintf('       - Zonal mean .albd_cl.dat file saved\n')
-    % convert cloud albedo to 2D format for usage in ENTS
-    vo_albd_cl_2d = zeros(length(go_latm),length(go_lonm));
-    for i = 1:length(go_lonm)
-        vo_albd_cl_2d(:,i) = vo_albd_cl(:);
-    end
-    % save output
-    fprint_2DM(vo_albd_cl_2d(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd_cl.dat'],'%8.4f','%8.4f',true,false);
-    fprintf('       - Idealized 2D cloud albedo file saved\n')
+			% convert cloud albedo to 2D format for usage in ENTS
+			go_albd_cl = zeros(length(go_latm),length(go_lonm));
+			for i = 1:length(go_lonm)
+				go_albd_cl(:,i) = vo_albd_cl(:);
+			end    
+			% save output
+			fprint_2DM(go_albd_cl(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd_cl.dat'],'%8.4f','%8.4f',true,false);
+			fprintf('       - Generic 2D cloud albedo file saved\n')
+			fprint_1Dn(vo_albd_cl(:),[[str_dirout '/' str_nameout] '.albd_cl.dat'],'%8.4f','%8.4f',true,false);
+			fprintf('       - Generic zonal mean .albd_cl.dat file saved\n')
+	end
+    
+
 end
 %
 % *** LOAD ICE MASK & OROGRAPHY DATA ************************************ %

--- a/muffingen.m
+++ b/muffingen.m
@@ -1321,22 +1321,7 @@ end
 n_step = n_step+1;
 %
 % for ENTS-enabled configs
-% NOTE: for now, assuming HadCM3(L)
 if opt_makeents
-    %
-    disp(['>  ' num2str(n_step) '. LOADING & PROCESSING FULL ALBEDO PRODUCTS  ...']);
-    %
-    % NOTE: gi_albd_cloud == cloud albedo diagnosed from planetary and surface albedo products
-    [gi_albd_planet gi_albd_surface gi_albd_cloud] = fun_read_albd_all_hadcm3x(str);
-    disp(['       - Read full GCM albedo products.']);
-    % plot full set of albedo products
-    if (opt_plots), plot_2dgridded(flipud(gi_albd),100.0,'',[[str_dirout '/' str_nameout] '.albd_in'],['albedo in']); end
-    
-    % NOTE: gi_albd_cloud_sw == cloud albedo diagnosed from SW fluxes
-    [gi_albd_cloud_sw] = fun_read_albd_sw_hadcm3x(str);
-    disp(['       - Read GCM albedo derived from SW fluxes.']);
-    
-    
     
 end
 %

--- a/muffingen.m
+++ b/muffingen.m
@@ -1248,7 +1248,7 @@ if opt_makealbedo
     %
     switch str(1).gcm
         case {'hadcm3','hadcm3l','foam','cesm','rockee'}
-            % read albedo
+            % read planetary albedo
             if (strcmp(str(1).gcm,'hadcm3') || strcmp(str(1).gcm,'hadcm3l'))
                 [gi_albd] = fun_read_albd_hadcm3x(str);
             elseif (strcmp(str(1).gcm,'foam'))
@@ -1260,7 +1260,7 @@ if opt_makealbedo
             end
             disp(['       - Read GCM albedo data.']);
             % plot input albedo
-            if (opt_plots), plot_2dgridded(flipud(gi_albd),100.0,'',[[str_dirout '/' str_nameout] '.albd_in'],['albedo in']); end
+            if (opt_plots), plot_2dgridded(flipud(gi_albd),100.0,'',[[str_dirout '/' str_nameout] '.albd_pl_in'],['planetary albedo in']); end
         otherwise
             disp(['         (Nothing to load.)']);
     end
@@ -1281,38 +1281,38 @@ if opt_makealbedo
             [go_albd,go_falbd] = make_regrid_2d(gi_lonae,gi_latae,gi_albd',go_lone,go_late,opt_debug);
             go_albd  = go_albd';
             go_falbd = go_falbd';
-            disp(['       - Re-gridded GCM albedo data.']);
+            disp(['       - Re-gridded GCM planetary albedo data.']);
             % plot output albedo
-            if (opt_plots), plot_2dgridded(flipud(go_albd),100.0,'',[[str_dirout '/' str_nameout] '.albd_out'],['albedo out']); end
+            if (opt_plots), plot_2dgridded(flipud(go_albd),100.0,'',[[str_dirout '/' str_nameout] '.albd_pl_out'],['albedo out']); end
             % save 2D file
-            fprint_2DM(go_albd(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd.dat'],'%8.4f','%8.4f',true,false);
-            fprintf('       - 2D albedo file saved\n')
+            fprint_2DM(go_albd(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd_pl.dat'],'%8.4f','%8.4f',true,false);
+            fprintf('       - 2D planetary albedo file saved\n')
             % create zonal mean
             vo_albd = mean(go_albd');
-            disp(['       - Generated zonal mean albedo profile.']);
+            disp(['       - Generated zonal mean planetary albedo profile.']);
         otherwise
             % NOTE: if age == 0, then default (modern) GENIE,
             %       otherwise for generic ice-free world
             vo_albd = make_grid_albd(go_latm,par_age);
-            disp(['       - Created generic zonal mean albedo profile.'])
+            disp(['       - Created generic zonal mean planetary albedo profile.'])
             % plot output albedo profile
             figure;
             scatter(go_latm,vo_albd);
             axis([-90 90 0.0 1.0]);
             xlabel('Latitude');
             ylabel('Albedo');
-            title('Zonally averaged albedo profile');
-            print('-dpsc2', [[str_dirout '/' str_nameout] '.zonalalbd.' str_date '.ps']);
+            title('Zonally averaged planetary albedo profile');
+            print('-dpsc2', [[str_dirout '/' str_nameout] '.zonalalbd_pl.' str_date '.ps']);
             % reorientate albedo vector for saving
             vo_albd = fliplr(vo_albd);
     end
-    % save albedo vector
-    % NOTE: when the file is read in by GENIE, it counrs down in j value:
+    % save planetary albedo vector
+    % NOTE: when the file is read in by GENIE, it counts down in j value:
     %       such that the N pole is the first element in file;
     %       fprint_1Dn saves the 2st row at the top, hence the vector
     %       must be orientated as in a map orientation (N at top)
-    fprint_1Dn(vo_albd(:),[[str_dirout '/' str_nameout] '.albd.dat'],'%8.4f','%8.4f',true,false);
-    fprintf('       - .albd.dat file saved\n')
+    fprint_1Dn(vo_albd(:),[[str_dirout '/' str_nameout] '.albd_pl.dat'],'%8.4f','%8.4f',true,false);
+    fprintf('       - Zonal mean .albd_pl.dat file saved\n')
     %
 end
 %
@@ -1322,7 +1322,78 @@ n_step = n_step+1;
 %
 % for ENTS-enabled configs
 if opt_makeents
-    
+    %
+    disp(['>  ' num2str(n_step) '. LOADING SURFACE & CLOUD ALBEDO DATA ...']);
+    %
+    switch str(1).gcm
+        case {'hadcm3','hadcm3l'}
+            [~,gi_albd_sur,gi_albd_cl] = fun_read_albd_hadcm3x_all(str);
+            disp(['       - Read GCM albedo data.']);
+            % plot input albedo
+            if (opt_plots)
+                plot_2dgridded(flipud(gi_albd_sur),100.0,'',[[str_dirout '/' str_nameout] '.albd_sur_in'],['surface albedo in']); 
+                plot_2dgridded(flipud(gi_albd_cl),100.0,'',[[str_dirout '/' str_nameout] '.albd_cl_in'],['cloud albedo in']); 
+            end
+        otherwise
+            disp(['         (Nothing to load.)']);
+    end
+    %
+    disp(['>  ' num2str(n_step) '. CREATING SURFACE & CLOUD ALBEDO DATA ...']);
+    %
+    switch str(1).gcm
+        case {'hadcm3','hadcm3l'}
+            % re-grid surface albedo
+            [go_albd_sur,go_falbd_sur] = make_regrid_2d(gi_lonae,gi_latae,gi_albd_sur',go_lone,go_late,opt_debug);
+            go_albd_sur  = go_albd_sur';
+            go_falbd_sur = go_falbd_sur';
+            disp(['       - Re-gridded GCM surface albedo data.']);
+            % re-grid cloud albedo
+            [go_albd_cl,go_falbd_cl] = make_regrid_2d(gi_lonae,gi_latae,gi_albd_cl',go_lone,go_late,opt_debug);
+            go_albd_cl  = go_albd_cl';
+            go_falbd_cl = go_falbd_cl';
+            disp(['       - Re-gridded GCM cloud albedo data.']);
+            % plot surface and cloud albedo output
+            if (opt_plots)
+                plot_2dgridded(flipud(go_albd_sur),100.0,'',[[str_dirout '/' str_nameout] '.albd_sur_out'],['surface albedo out']);
+                plot_2dgridded(flipud(go_albd_cl),100.0,'',[[str_dirout '/' str_nameout] '.albd_cl_out'],['cloud albedo out']);
+            end
+            % save 2D file
+            fprint_2DM(go_albd_sur(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd_sur.dat'],'%8.4f','%8.4f',true,false);
+            fprintf('       - 2D surface albedo file saved\n')
+            fprint_2DM(go_albd_cl(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd_cl.dat'],'%8.4f','%8.4f',true,false);
+            fprintf('       - 2D cloud albedo file saved\n')
+            % create zonal mean
+            vo_albd_sur = mean(go_albd_sur');
+            vo_albd_cl = mean(go_albd_cl');
+            disp(['       - Generated zonal mean surface and cloud albedo profiles.']);
+            % save surface and cloud albedo vectors
+            fprint_1Dn(vo_albd_sur(:),[[str_dirout '/' str_nameout] '.albd_sur.dat'],'%8.4f','%8.4f',true,false);
+            fprintf('       - Zonal mean .albd_sur.dat file saved\n')
+        otherwise
+            % generate idealized cloud albedo
+            % NOTE: if age == 0, then default (modern) GENIE,
+            %       otherwise for generic ice-free world
+            [~,vo_albd_cl]  = make_grid_albd_all(go_latm,par_age);
+            disp(['       - Created generic zonal mean cloud albedo profile.'])
+            % plot output cloud albedo profile
+            figure; scatter(go_latm,vo_albd_cl);
+            axis([-90 90 0.0 1.0]);
+            xlabel('Latitude'); ylabel('Cloud albedo');
+            title('Zonally averaged cloud albedo profile');
+            print('-dpsc2', [[str_dirout '/' str_nameout] '.zonalalbd_cl.' str_date '.ps']);
+            % reorientate albedo vector for saving
+            vo_albd_cl = fliplr(vo_albd_cl);
+    end
+    fprint_1Dn(vo_albd_cl(:),[[str_dirout '/' str_nameout] '.albd_cl.dat'],'%8.4f','%8.4f',true,false);
+    fprintf('       - Zonal mean .albd_cl.dat file saved\n')
+    % convert cloud albedo to 2D format for usage in ENTS
+    vo_albd_cl_2d = zeros(length(go_latm),length(go_lonm));
+    for i = 1:length(go_lonm)
+        vo_albd_cl_2d(:,i) = vo_albd_cl(:);
+    end
+    % save output
+    fprint_2DM(vo_albd_cl_2d(:,:),[],[[str_dirout '/' str_nameout] '.2Dalbd_cl.dat'],'%8.4f','%8.4f',true,false);
+    fprintf('       - Idealized 2D cloud albedo file saved\n')
 end
 %
 % *** LOAD ICE MASK & OROGRAPHY DATA ************************************ %
@@ -1330,16 +1401,24 @@ end
 n_step = n_step+1;
 %
 % for ENTS-enabled configs
-% NOTE: for now, assuming HadCM3(L)
+% NOTE: for now, allow HadCM3(L) input only
+%       make flat orography for other inputs
+%       make snow-free mask for other inputs
 if opt_makeents
     %
     disp(['>  ' num2str(n_step) '. LOADING ICE MASK & OROGRAPHY DATA ...']);
     %
-    [gi_imask] = fun_read_imask_hadcm3x(str);
-    [gi_orog]  = fun_read_orog_hadcm3x(str);
-    % plot input mask & topo
-    if (opt_plots), plot_2dgridded(flipud(gi_imask),2.0,'',[[str_dirout '/' str_nameout] '.imask_in'],['mask in']); end
-    if (opt_plots), plot_2dgridded(flipud(gi_orog),6000.0,'',[[str_dirout '/' str_nameout] '.orog_in'],['topo in']); end
+    switch str(1).gcm
+        case {'hadcm3','hadcm3l'}
+            [gi_imask] = fun_read_imask_hadcm3x(str);
+            [gi_orog]  = fun_read_orog_hadcm3x(str);
+            disp(['       - Read GCM orography and icemask data.']);
+            % plot input mask & topo
+            if (opt_plots), plot_2dgridded(flipud(gi_imask),2.0,'',[[str_dirout '/' str_nameout] '.imask_in'],['mask in']); end
+            if (opt_plots), plot_2dgridded(flipud(gi_orog),6000.0,'',[[str_dirout '/' str_nameout] '.orog_in'],['topo in']); end
+        otherwise
+            disp(['         (Nothing to load.)']);
+    end
 end
 %
 % *** RE-GRID ICE MASK & OROGRAPHY DATA ********************************* %
@@ -1347,57 +1426,71 @@ end
 n_step = n_step+1;
 %
 % for ENTS-enabled configs
-% NOTE: for now, assuming HadCM3(L)
+% NOTE: for now, assuming HadCM3(L) where ice=1 & no ice=0
 % NOTE: the ice mask is not changed after this point
 % NOTE: ice mask and orography on atmospheric grid
 if opt_makeents
     %
     disp(['>  ' num2str(n_step) '. CREATING ICE MASK & OROGRAPHY DATA ...']);
-    % ice mask
-    [go_imask,go_tmp] = make_regrid_2d(gi_lonae,gi_latae,gi_imask',go_lone,go_late,opt_debug);
-    go_imask  = go_imask';
-    go_tmp    = go_tmp';
-    disp(['       - Ice mask re-gridded.']);
-    disp(['         NOTE: The ice mask is not adjusted after this point and so may need to be hand-edited if the land-sea mask changes.']);
-    if (opt_plots), plot_2dgridded(flipud(go_imask),99999.0,'',[[str_dirout '/' str_nameout] '.imask_out.RAW'],['Ice mask out -- RAW']); end
-    fprint_2DM(go_imask(:,:),[],[[str_dirout '/' str_nameout] '.imask_out.RAW.dat'],'%4.1f','%4.1f',true,false);
-    % apply FINAL land-sea mask (no icesheet (==0) over ocean)
-    go_imask = go_imask.*(1-go_mask);
-    if (opt_plots), plot_2dgridded(flipud(go_imask),99999.0,'',[[str_dirout '/' str_nameout] '.imask_out.FINAL'],['Ice mask out -- FINAL version']); end
-    fprint_2DM(go_imask(:,:),[],[[str_dirout '/' str_nameout] '.imask_out.FINAL.dat'],'%4.1f','%4.1f',true,false);
-    % orography
-    [go_orog,go_tmp] = make_regrid_2d(gi_lonae,gi_latae,gi_orog',go_lone,go_late,opt_debug);
-    go_orog  = go_orog';
-    go_tmp   = go_tmp';
-    disp(['       - Orography re-gridded.']);
-    if (opt_plots), plot_2dgridded(flipud(go_orog),99999.0,'',[[str_dirout '/' str_nameout] '.orog_out.RAW'],['Orography out -- RAW']); end
-    fprint_2DM(go_orog(:,:),1-go_mask(:,:),[[str_dirout '/' str_nameout] '.orog_out.RAW.dat'],'%10.2f','%10i',true,true); 
-    % apply FINAL land-sea mask
-    % NOTE: ocean mask has 1 == ocean
-    % NOTE: at this point, re-gridded cells with no orographic information == NaN
-    %       while land cells in the mask are zero
-    %       becasue the mask might have changed compared to the orographic grid, we need:
-    %       (1) ocean cells to be NaN in the orographic grid irrespective of the original orographic re-gridding
-    %       (2) land cells which are NaN in the orographic grid, to be zero
-    %           (i.e. in the absence of GCM info, we are going to place 'new' land at sealevel
-    % (1)
-    go_orog(find(go_mask==1)) = NaN;
-    % (2) 
-    go_orog(intersect(find(go_mask==0),find(go_orog==NaN))) = 0.0;
     %
-    if (opt_plots), plot_2dgridded(flipud(go_orog),99999.0,'',[[str_dirout '/' str_nameout] '.orog_out.FINAL'],['Orography out -- FINAL version']); end
-    fprint_2DM(go_orog(:,:),1-go_mask(:,:),[[str_dirout '/' str_nameout] '.orog_out.FINAL.dat'],'%10.2f','%10i',true,true);
-    % create and save combined ENTS mask
-    % NOTE: Ocean = 0; Land = 1; Ice sheet = 2
-    %       (=> invert ocean mask, then add ice mask)
-    % NOTE: first convert fractional ice mask to (1,0): assume a thresold of 0.5
-    i_imask = find(go_imask(:,:) > 0.5);
-    go_imask(:,:) = 0.0;
-    go_imask(i_imask) = 1.0;
-    go_olimask(:,:) = 1 - go_mask(:,:);
-    go_olimask(:,:) = go_olimask(:,:) + go_imask(:,:);
-    if (opt_plots), plot_2dgridded(flipud(go_olimask),99999.0,'',[[str_dirout '/' str_nameout] '.olimask_out.FINAL'],['ocean-land-ice mask out -- FINAL version']); end
-    fprint_2DM(go_olimask(:,:),[],[[str_dirout '/' str_nameout] '.olimask_out.FINAL.dat'],'%3i','%3i',true,false);
+    switch str(1).gcm
+        case {'hadcm3','hadcm3l'}
+            % regrid ice mask
+            [go_imask,go_tmp] = make_regrid_2d(gi_lonae,gi_latae,gi_imask',go_lone,go_late,opt_debug);
+            go_imask  = go_imask';
+            go_tmp    = go_tmp';
+            % plot raw data (not adjusted for land-sea mask)
+            if (opt_plots), plot_2dgridded(flipud(go_imask),99999.0,'',[[str_dirout '/' str_nameout] '.imask_out.RAW'],['Ice mask out -- RAW']); end
+            fprint_2DM(go_imask(:,:),[],[[str_dirout '/' str_nameout] '.imask_out.RAW.dat'],'%4.1f','%4.1f',true,false);
+            % apply FINAL land-sea mask (no icesheet (==0) over ocean)
+            go_imask = go_imask.*(1-go_mask);
+            disp(['       - Ice mask re-gridded.']);
+            disp(['         NOTE: Ice mask is not adjusted after this point so may need to be hand-edited if the land-sea mask changes.']);
+            if (opt_plots), plot_2dgridded(flipud(go_imask),99999.0,'',[[str_dirout '/' str_nameout] '.imask_out.FINAL'],['Ice mask out -- FINAL version']); end
+            fprint_2DM(go_imask(:,:),[],[[str_dirout '/' str_nameout] '.imask_out.FINAL.dat'],'%4.1f','%4.1f',true,false);
+            % orography
+            [go_orog,go_tmp] = make_regrid_2d(gi_lonae,gi_latae,gi_orog',go_lone,go_late,opt_debug);
+            go_orog  = go_orog';
+            go_tmp   = go_tmp';
+            disp(['       - Orography re-gridded.']);
+            if (opt_plots), plot_2dgridded(flipud(go_orog),99999.0,'',[[str_dirout '/' str_nameout] '.orog_out.RAW'],['Orography out -- RAW']); end
+            fprint_2DM(go_orog(:,:),1-go_mask(:,:),[[str_dirout '/' str_nameout] '.orog_out.RAW.dat'],'%10.2f','%10i',true,true);
+            % apply FINAL land-sea mask
+            % NOTE: ocean mask has 1 == ocean
+            % NOTE: at this point, re-gridded cells with no orographic information == NaN
+            %       while land cells in the mask are zero
+            %       because the mask might have changed compared to the orographic grid, we need:
+            %       (1) ocean cells to be NaN in the orographic grid irrespective of the original orographic re-gridding
+            %       (2) land cells which are NaN in the orographic grid, to be zero
+            %           (i.e. in the absence of GCM info, we are going to place 'new' land at sealevel
+            % (1)
+            go_orog(find(go_mask==1)) = NaN;
+            % (2)
+            go_orog(intersect(find(go_mask==0),find(go_orog==NaN))) = 0.0;
+            %
+            if (opt_plots), plot_2dgridded(flipud(go_orog),99999.0,'',[[str_dirout '/' str_nameout] '.orog_out.FINAL'],['Orography out -- FINAL version']); end
+            % create and save combined ENTS mask
+            % NOTE: Ocean = 0; Land = 1; Ice sheet = 2
+            %       (=> invert ocean mask, then add ice mask)
+            % NOTE: first convert fractional ice mask to (1,0): assume a thresold of 0.5
+            i_imask = find(go_imask(:,:) > 0.5);
+            go_imask(:,:) = 0.0;
+            go_imask(i_imask) = 1.0;
+            go_licemask(:,:) = (1 - go_mask(:,:)) + go_imask(:,:);
+            if (opt_plots), plot_2dgridded(flipud(go_licemask),99999.0,'',[[str_dirout '/' str_nameout] '.licemask_out.FINAL'],['Land-ice mask out -- FINAL version']); end
+        otherwise
+            % generate flat orography at 840 m ==> mean modern land elevation
+            go_orog = abs(go_mask-1)*840;
+            disp(['       - Created flat orography.']);
+            % generate ice-free land-ice mask
+            % NOTE: Ocean = 0; Land = 1; Ice sheet = 2
+            %       (=> invert ocean mask, do not add ice)
+            go_licemask = abs(go_mask-1);
+            disp(['       - Created ice-free icemask.']);
+    end
+    % print to textfile
+    fprint_2DM(go_orog(:,:),1-go_mask(:,:),[[str_dirout '/' str_nameout] '.orography.dat'],'%10.2f','%10i',true,true);
+    fprint_2DM(go_licemask(:,:),[],[[str_dirout '/' str_nameout] '.licemask.dat'],'%3i','%3i',true,false);
 end
 %
 % *** GENERATE CONFIG FILE PARAMETER LINES ****************************** %
@@ -1449,16 +1542,24 @@ fprintf(fid,'%s\n',['ea_taux_v=''',par_wor_name,'.taux_v.dat''']);
 fprintf(fid,'%s\n',['ea_tauy_v=''',par_wor_name,'.tauy_v.dat''']);
 fprintf(fid,'%s\n',['ea_adv_u=''',par_wor_name,'.wvelx.dat''']);
 fprintf(fid,'%s\n',['ea_adv_v=''',par_wor_name,'.wvely.dat''']);
+% Boundary conditions: PLANETARY ALBEDO
+if opt_makealbedo
+    fprintf(fid,'%s\n','# Boundary conditions: ALBEDO (planetary)');
+    fprintf(fid,'%s\n',['ea_par_albedo1d_name=''',par_wor_name,'.albd_pl.dat''']);
+end
 % Boundary conditions: GOLDSTEIN
 fprintf(fid,'%s\n','# Boundary conditions: GOLDSTEIN');
 fprintf(fid,'%s\n',['go_topo=''',par_wor_name,'''']);
 % Boundary conditions: GOLDSTEIN sea-ice
 fprintf(fid,'%s\n','# Boundary conditions: GOLDSTEIN sea-ice');
 fprintf(fid,'%s\n',['gs_topo=''',par_wor_name,'''']);
-% Boundary conditions: ALBEDO!
-if opt_makealbedo
-    fprintf(fid,'%s\n','# Boundary conditions: ALBEDO!');
-    fprintf(fid,'%s\n',['ea_par_albedo1d_name=''',par_wor_name,'.albd.dat''']);
+% Boundary conditions: ENTS
+if opt_makeents
+    fprintf(fid,'%s\n','# Boundary conditions: ENTS');
+    fprintf(fid,'%s\n',['ea_filename_ents2d=.true.']);
+    fprintf(fid,'%s\n',['ea_filenameorog=''',par_wor_name,'.orography.dat''']);
+    fprintf(fid,'%s\n',['ea_filenamelice=''',par_wor_name,'.licemask.dat''']);
+    fprintf(fid,'%s\n',['ea_filenamealba=''',par_wor_name,'.2Dalbd_cl.dat''']);
 end
 % Boundary conditions: BIOGEM
 if (opt_makezonalwind)
@@ -1558,9 +1659,10 @@ if (par_age == 0.0)
     fprintf(fid,'%s\n','# ... also, salinity should be set 1 PSU lower if it an ice-free World');
     fprintf(fid,'%s\n',['###go_saln0=33.9']);
     fprintf(fid,'%s\n','# Orbital parameters (modern, defaults)');
-    fprintf(fid,'%s\n',['###ea_par_orbit_osce=','0.0167',' # eccentricity']);
-    fprintf(fid,'%s\n',['###ea_par_orbit_oscsob=','0.397789',' # sine of obliquity']);
-    fprintf(fid,'%s\n',['###ea_par_orbit_oscgam=','102.92',' # longitude of perihelion']);
+    fprintf(fid,'%s\n',['ea_opt_orbit_old =','.false.',' # flag NEW orbit code']);
+    fprintf(fid,'%s\n',['ea_par_orbit_osce=','0.0167',' # eccentricity']);
+    fprintf(fid,'%s\n',['ea_par_orbit_oscobl=','0.409093',' # obliquity (rad)']);
+    fprintf(fid,'%s\n',['ea_par_orbit_osclonperi=','1.796257',' # true longitude of perihelion (rad)']);
 else
     loc_per = 100.0*(1-1/(1+(2/5)*(1-(4.570E+03-par_age)/4.570E+03)));
     loc_S0  = 1.368E+03*(100-loc_per)/100;
@@ -1569,9 +1671,10 @@ else
     fprintf(fid,'%s\n','# Ocean salinity -- assuming an ice-free World (1 PSU lower than modern)');
     fprintf(fid,'%s\n',['go_saln0=33.9']);
     fprintf(fid,'%s\n','# Orbital parameters -- modern set => adjust as necessary');
+    fprintf(fid,'%s\n',['ea_opt_orbit_old =','.false.',' # flag NEW orbit code']);
     fprintf(fid,'%s\n',['ea_par_orbit_osce=','0.0167',' # eccentricity']);
-    fprintf(fid,'%s\n',['ea_par_orbit_oscsob=','0.397789',' # sine of obliquity']);
-    fprintf(fid,'%s\n',['ea_par_orbit_oscgam=','102.92',' # longitude of perihelion']);
+    fprintf(fid,'%s\n',['ea_par_orbit_oscobl=','0.409093',' # obliquity (rad)']);
+    fprintf(fid,'%s\n',['ea_par_orbit_osclonperi=','1.796257',' # true longitude of perihelion (rad)']);
 end
 % ocean Ca/Mg (and SO4)
 % From: Zeebe and Tyrrell [2019]

--- a/muffingen.m
+++ b/muffingen.m
@@ -354,6 +354,7 @@ if opt_makeall
     opt_makerunoff=true;  %
     opt_makewind=true;    %
     opt_makealbedo=true;  %
+	opt_makeents=true;    %
     opt_makeseds=true;    %
     opt_filtermask=true;  %
     opt_filtertopo=true;  %

--- a/source/fun_read_albd_foam_all.m
+++ b/source/fun_read_albd_foam_all.m
@@ -1,0 +1,90 @@
+function [grid_albd_planet,grid_albd_surface,grid_albd_cloud]  = fun_read_albd_foam_all(str)
+%
+%%
+
+% *********************************************************************** %
+% *** READ AND RETURN ALBEDO ******************************************** %
+% *********************************************************************** %
+%
+% str input KEY:
+% str(1).nc == par_nc_axes_name
+% str(2).nc == par_nc_topo_name
+% str(3).nc == par_nc_atmos_name
+% str(4).nc == par_nc_ocean_name
+% str(5).nc == par_nc_coupl_name
+%
+% open netCDF file
+ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(3).nc '.nc'],'nowrite');
+% incoming (TOA) solar radiation
+% NOTE: SOLIN(time=12, lat=40, lon=48)
+varid = netcdf.inqVarID(ncid,'SOLIN');
+solin(:,:,:) = netcdf.getVar(ncid,varid);
+% net (TOA) solar radiation at top (incoming minus outgoing)
+% NOTE: FSNT(time=12, lat=40, lon=48)
+varid = netcdf.inqVarID(ncid,'FSNT');
+fsnt(:,:,:) = netcdf.getVar(ncid,varid);
+% downward solar flux at surface (clear sky)
+% NOTE: FSDSC(time=12, lat=40, lon=48)
+varid = netcdf.inqVarID(ncid,'FSDSC');
+fsdsc(:,:,:) = netcdf.getVar(ncid,varid);
+% downward solar flux at surface (cloudy sky)
+% NOTE: FSDSC(time=12, lat=40, lon=48)
+varid = netcdf.inqVarID(ncid,'FSDS');
+fsds(:,:,:) = netcdf.getVar(ncid,varid);
+% net solar flux at surface 
+% NOTE: FSDSC(time=12, lat=40, lon=48)
+varid = netcdf.inqVarID(ncid,'FSNS');
+fsns(:,:,:) = netcdf.getVar(ncid,varid);
+% close netCDF file
+netcdf.close(ncid);
+% create annual averages
+grid_solin = 0.0*solin(:,:,1);
+grid_fsnt  = 0.0*fsnt(:,:,1);
+grid_fsdsc = 0.0*fsdsc(:,:,1);
+grid_fsds  = 0.0*fsds(:,:,1);
+grid_fsns  = 0.0*fsns(:,:,1);
+for t=1:12
+    grid_solin = grid_solin+ solin(:,:,t)/12.0;
+    grid_fsnt  = grid_fsnt + fsnt(:,:,t)/12.0;
+    grid_fsdsc  = grid_fsdsc + fsdsc(:,:,t)/12.0;
+    grid_fsds  = grid_fsds + fsds(:,:,t)/12.0;
+    grid_fsns  = grid_fsns + fsns(:,:,t)/12.0;
+end
+% remove zeros ...
+grid_solin(find(grid_solin<=0.0)) = NaN;
+grid_fsnt(find(grid_fsnt<=0.0))   = NaN;
+grid_fsdsc(find(grid_fsdsc<=0.0)) = NaN;
+grid_fsds(find(grid_fsds<=0.0))   = NaN;
+grid_fsns(find(grid_fsns<=0.0))   = NaN;
+%
+% calculate (planetary) albedo
+% NOTE: reflected outgoing = (grid_solin-grid_fsnt)
+grid_albd_planet = (grid_solin-grid_fsnt)./grid_solin;
+% NOTE: format needed is: [LAT,LON] (rows x columns) orientation
+grid_albd_planet = flipud(grid_albd_planet');
+%
+% calculate (atmospheric) albedo
+% NOTE: (FSDSC-FSDS)/SOLIN
+% NOTE: difference btween 'clear-sky' and 'cloud sky' downward shortwave
+grid_albd_cloud = (grid_fsdsc-grid_fsds)./grid_solin;
+% NOTE: format needed is: [LAT,LON] (rows x columns) orientation
+grid_albd_cloud = flipud(grid_albd_cloud');
+%
+% calculate (surface) albedo
+% NOTE: (FSDS-FSNS)/FSDS
+grid_albd_surface = (grid_fsds-grid_fsns)./grid_fsds;
+% NOTE: format needed is: [LAT,LON] (rows x columns) orientation
+grid_albd_surface = flipud(grid_albd_surface');
+%
+%
+
+%
+% *********************************************************************** %
+
+% *********************************************************************** %
+% *** END *************************************************************** %
+% *********************************************************************** %
+%
+%%%
+%
+% *********************************************************************** %

--- a/source/fun_read_albd_hadcm3x.m
+++ b/source/fun_read_albd_hadcm3x.m
@@ -32,7 +32,8 @@ ncid = netcdf.open([str_path '/' str(3).nc '.nc'],'nowrite');
 % NOTE: albedop(time=18, lat=73, lon=96)
 varid  = netcdf.inqVarID(ncid,'albedop');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
-grid_albd = double(albd(:,:,13));
+grid_albd = double(albd(:,:));
+%grid_albd = double(albd(:,:,13));
 % NOTE: format needed is: [LAT,LON] (rows x columns) orientation
 %       => flip up-down & transpose to give a readable ASCII array
 % NOTE: for some reason this field does not need flipud-ing ... ??

--- a/source/fun_read_albd_hadcm3x.m
+++ b/source/fun_read_albd_hadcm3x.m
@@ -32,8 +32,7 @@ ncid = netcdf.open([str_path '/' str(3).nc '.nc'],'nowrite');
 % NOTE: albedop(time=18, lat=73, lon=96)
 varid  = netcdf.inqVarID(ncid,'albedop');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
-grid_albd = double(albd(:,:));
-%grid_albd = double(albd(:,:,13));
+grid_albd = double(albd(:,:,13));
 % NOTE: format needed is: [LAT,LON] (rows x columns) orientation
 %       => flip up-down & transpose to give a readable ASCII array
 % NOTE: for some reason this field does not need flipud-ing ... ??

--- a/source/fun_read_albd_hadcm3x_all.m
+++ b/source/fun_read_albd_hadcm3x_all.m
@@ -38,21 +38,21 @@ ncid = netcdf.open([str_path '/' str(3).nc '.nc'],'nowrite');
 % NOTE: albedop = upSol_mm_s3_TOA./downSol_mm_TOA;
 varid  = netcdf.inqVarID(ncid,'albedop');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
+%gi_albd_planet = double(albd(:,:))';
 gi_albd_planet = double(albd(:,:,13))';
 % ALBEDO -- SURFACE
 % NOTE: albedos = (downSol_Seaice_mm_s3_srf-solar_mm_s3_srf)./downSol_Seaice_mm_s3_srf;
 varid  = netcdf.inqVarID(ncid,'albedos');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
+%gi_albd_surface = double(albd(:,:))';
 gi_albd_surface = double(albd(:,:,13))';
 % close netCDF file
 netcdf.close(ncid);
 %
 % ALBEDO -- CLOUD 
+% NOTE: no hadCM3 output -- needs manual calculation
 % open netCDF files
 ncid = netcdf.open([str_path '/' str(1).nc '.nc'],'nowrite');
-% load and process data
-% NOTE: VAR(lat=73, lon=96) ==> annual means
-% NOTE: no hadCM3 output -- needs manual calculation
 varid  = netcdf.inqVarID(ncid,'downSol_Seaice_mm_s3_srf');
 downSol_srf(:,:) = netcdf.getVar(ncid,varid);
 varid  = netcdf.inqVarID(ncid,'upSol_mm_s3_TOA');
@@ -65,15 +65,24 @@ netcdf.close(ncid);
 downSol_srf = downSol_srf';
 upSol_TOA = upSol_TOA';
 downSol_TOA = downSol_TOA';
-%
+
 % calculate upSol_srf (reflected from surface)
 upSol_srf = gi_albd_surface.*downSol_srf;
 % calculate diff between TOA outgoing solar and surface-reflected 
-% outgoing solar to obtain cloud-reflected fraction of outgoing solar energy
+% outgoing solar to obtain cloud-reflected outgoing solar energy
 upSol_Cloud = upSol_TOA - upSol_srf;
 % calculate cloud albedo and 
 gi_albd_cloud = (upSol_Cloud./downSol_TOA);
-%
+
+
+% % load
+% downSol_mm_TOA=ncread([str_path '/' str(1).nc '.nc'],'downSol_mm_TOA');
+% downSol_Seaice_mm_s3_srf=ncread([str_path '/' str(1).nc '.nc'],'downSol_Seaice_mm_s3_srf');
+% 
+% %transpose
+% downSol_mm_TOA=downSol_mm_TOA';
+% downSol_Seaice_mm_s3_srf=downSol_Seaice_mm_s3_srf';
+
 %
 % *********************************************************************** %
 

--- a/source/fun_read_albd_hadcm3x_all.m
+++ b/source/fun_read_albd_hadcm3x_all.m
@@ -1,4 +1,4 @@
-function [gi_albd_planet gi_albd_surface gi_albd_cloud gi_albd_cloud_sw]  = fun_read_albd_hadcm3x_all(str)
+function [gi_albd_planet,gi_albd_surface,gi_albd_cloud]  = fun_read_albd_hadcm3x_all(str)
 %
 %%
 
@@ -33,39 +33,56 @@ ncid = netcdf.open([str_path '/' str(3).nc '.nc'],'nowrite');
 % NOTE: format needed is: [LAT,LON] (rows x columns) orientation
 %       => flip up-down & transpose to give a readable ASCII array
 % NOTE: for some reason this field does not need flipud-ing ... ??
-% NOTE: to derive alpha(c) from alpha(p) and alpha(s), assume:
-%       alpha(p) = alpha(c) + (1 - alpha(c))*alpha(s)
-%       => alpha(c)/(1 - alpha(c)) = alpha(p)/alpha(s)
-%       => (1 - alpha(c))/alpha(c) = alpha(s)/alpha(p)
-%       => 1/alpha(c) - 1 = alpha(s)/alpha(p)
-%       => alpha(c) = 1 / (1 + alpha(s)/alpha(p))
 %
 % ALBEDO -- PLANETARY
+% NOTE: albedop = upSol_mm_s3_TOA./downSol_mm_TOA;
 varid  = netcdf.inqVarID(ncid,'albedop');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
-gi_albd_planet = double(albd(:,:,13))';
+gi_albd_planet = double(albd(:,:))';
+%gi_albd_planet = double(albd(:,:,13))';
 % ALBEDO -- SURFACE
+% NOTE: albedos = (downSol_Seaice_mm_s3_srf-solar_mm_s3_srf)./downSol_Seaice_mm_s3_srf;
 varid  = netcdf.inqVarID(ncid,'albedos');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
-gi_albd_surface = double(albd(:,:,13))';
-% ALBEDO -- CLOUD (diagnosed from above)
-gi_albd_cloud = 1 ./ (1.0 + gi_albd_surface./gi_albd_planet);
-%
-% NOTE: to derive cloud albedo from SW fluxes:
-%       alpha(c) = 1.0 - SWdown(sur)/SWdown(TOA)
-% SW (net solar) -- TOA down
-varid  = netcdf.inqVarID(ncid,'netsolar');
-sw(:,:,:) = netcdf.getVar(ncid,varid);
-gi_sw_toa = double(sw(:,:,13))';
-% SW -- surface down
-varid  = netcdf.inqVarID(ncid,'albedos');
-sw(:,:,:) = netcdf.getVar(ncid,varid);
-gi_sw_surface = double(sw(:,:,13))';
-% ALBEDO -- CLOUD (diagnosed from above)
-gi_albd_cloud_sw = 1.0 - gi_sw_surface./gi_sw_toa;
-%
+gi_albd_surface = double(albd(:,:))';
+%gi_albd_surface = double(albd(:,:,13))';
 % close netCDF file
 netcdf.close(ncid);
+%
+% ALBEDO -- CLOUD 
+% NOTE: no hadCM3 output -- needs manual calculation
+% open netCDF files
+ncid = netcdf.open([str_path '/' str(1).nc '.nc'],'nowrite');
+varid  = netcdf.inqVarID(ncid,'downSol_Seaice_mm_s3_srf');
+downSol_srf(:,:) = netcdf.getVar(ncid,varid);
+varid  = netcdf.inqVarID(ncid,'upSol_mm_s3_TOA');
+upSol_TOA(:,:) = netcdf.getVar(ncid,varid);
+varid  = netcdf.inqVarID(ncid,'downSol_mm_TOA');
+downSol_TOA(:,:) = netcdf.getVar(ncid,varid);
+% close netCDF file
+netcdf.close(ncid);
+% transpose
+downSol_srf = downSol_srf';
+upSol_TOA = upSol_TOA';
+downSol_TOA = downSol_TOA';
+
+% calculate upSol_srf (reflected from surface)
+upSol_srf = gi_albd_surface.*downSol_srf;
+% calculate diff between TOA outgoing solar and surface-reflected 
+% outgoing solar to obtain cloud-reflected outgoing solar energy
+upSol_Cloud = upSol_TOA - upSol_srf;
+% calculate cloud albedo and 
+gi_albd_cloud = (upSol_Cloud./downSol_TOA);
+
+
+% % load
+% downSol_mm_TOA=ncread([str_path '/' str(1).nc '.nc'],'downSol_mm_TOA');
+% downSol_Seaice_mm_s3_srf=ncread([str_path '/' str(1).nc '.nc'],'downSol_Seaice_mm_s3_srf');
+% 
+% %transpose
+% downSol_mm_TOA=downSol_mm_TOA';
+% downSol_Seaice_mm_s3_srf=downSol_Seaice_mm_s3_srf';
+
 %
 % *********************************************************************** %
 

--- a/source/fun_read_albd_hadcm3x_all.m
+++ b/source/fun_read_albd_hadcm3x_all.m
@@ -1,0 +1,78 @@
+function [gi_albd_planet gi_albd_surface gi_albd_cloud gi_albd_cloud_sw]  = fun_read_albd_hadcm3x_all(str)
+%
+%%
+
+% *********************************************************************** %
+% *** READ AND RETURN ALBEDO ******************************************** %
+% *********************************************************************** %
+%
+% str input KEY:
+% str(1).nc == par_nc_axes_name
+% str(2).nc == par_nc_topo_name
+% str(3).nc == par_nc_atmos_name
+% str(4).nc == par_nc_ocean_name
+% str(5).nc == par_nc_coupl_name
+%
+str_path = [str(1).path '/' str(1).exp];
+if ~(exist([str_path '/' str(3).nc '.nc'],'file') == 2),
+    if (exist([str_path '/' str(3).nc '.zip'],'file') == 2),
+        unzip([str_path '/' str(3).nc '.zip'],str_path);
+        fprintf('       - Extracted zipped netCDF file.\n')
+    else
+        disp(['       * ERROR: file ' [str_path '/' str(3).nc '.nc'] ' cannot be found (nor a zipped version)']);
+        disp(['--------------------------------------------------------']);
+        disp([' ']);
+        diary off;
+        return;
+    end
+end
+% open netCDF file
+ncid = netcdf.open([str_path '/' str(3).nc '.nc'],'nowrite');
+% load and process data
+% NOTE: albedop(time=18, lat=73, lon=96)
+% NOTE: format needed is: [LAT,LON] (rows x columns) orientation
+%       => flip up-down & transpose to give a readable ASCII array
+% NOTE: for some reason this field does not need flipud-ing ... ??
+% NOTE: to derive alpha(c) from alpha(p) and alpha(s), assume:
+%       alpha(p) = alpha(c) + (1 - alpha(c))*alpha(s)
+%       => alpha(c)/(1 - alpha(c)) = alpha(p)/alpha(s)
+%       => (1 - alpha(c))/alpha(c) = alpha(s)/alpha(p)
+%       => 1/alpha(c) - 1 = alpha(s)/alpha(p)
+%       => alpha(c) = 1 / (1 + alpha(s)/alpha(p))
+%
+% ALBEDO -- PLANETARY
+varid  = netcdf.inqVarID(ncid,'albedop');
+albd(:,:,:) = netcdf.getVar(ncid,varid);
+gi_albd_planet = double(albd(:,:,13))';
+% ALBEDO -- SURFACE
+varid  = netcdf.inqVarID(ncid,'albedos');
+albd(:,:,:) = netcdf.getVar(ncid,varid);
+gi_albd_surface = double(albd(:,:,13))';
+% ALBEDO -- CLOUD (diagnosed from above)
+gi_albd_cloud = 1 ./ (1.0 + gi_albd_surface./gi_albd_planet);
+%
+% NOTE: to derive cloud albedo from SW fluxes:
+%       alpha(c) = 1.0 - SWdown(sur)/SWdown(TOA)
+% SW (net solar) -- TOA down
+varid  = netcdf.inqVarID(ncid,'netsolar');
+sw(:,:,:) = netcdf.getVar(ncid,varid);
+gi_sw_toa = double(sw(:,:,13))';
+% SW -- surface down
+varid  = netcdf.inqVarID(ncid,'albedos');
+sw(:,:,:) = netcdf.getVar(ncid,varid);
+gi_sw_surface = double(sw(:,:,13))';
+% ALBEDO -- CLOUD (diagnosed from above)
+gi_albd_cloud_sw = 1.0 - gi_sw_surface./gi_sw_toa;
+%
+% close netCDF file
+netcdf.close(ncid);
+%
+% *********************************************************************** %
+
+% *********************************************************************** %
+% *** END *************************************************************** %
+% *********************************************************************** %
+%
+%%%
+%
+% *********************************************************************** %

--- a/source/fun_read_albd_hadcm3x_all.m
+++ b/source/fun_read_albd_hadcm3x_all.m
@@ -38,21 +38,21 @@ ncid = netcdf.open([str_path '/' str(3).nc '.nc'],'nowrite');
 % NOTE: albedop = upSol_mm_s3_TOA./downSol_mm_TOA;
 varid  = netcdf.inqVarID(ncid,'albedop');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
-gi_albd_planet = double(albd(:,:))';
-%gi_albd_planet = double(albd(:,:,13))';
+gi_albd_planet = double(albd(:,:,13))';
 % ALBEDO -- SURFACE
 % NOTE: albedos = (downSol_Seaice_mm_s3_srf-solar_mm_s3_srf)./downSol_Seaice_mm_s3_srf;
 varid  = netcdf.inqVarID(ncid,'albedos');
 albd(:,:,:) = netcdf.getVar(ncid,varid);
-gi_albd_surface = double(albd(:,:))';
-%gi_albd_surface = double(albd(:,:,13))';
+gi_albd_surface = double(albd(:,:,13))';
 % close netCDF file
 netcdf.close(ncid);
 %
 % ALBEDO -- CLOUD 
-% NOTE: no hadCM3 output -- needs manual calculation
 % open netCDF files
 ncid = netcdf.open([str_path '/' str(1).nc '.nc'],'nowrite');
+% load and process data
+% NOTE: VAR(lat=73, lon=96) ==> annual means
+% NOTE: no hadCM3 output -- needs manual calculation
 varid  = netcdf.inqVarID(ncid,'downSol_Seaice_mm_s3_srf');
 downSol_srf(:,:) = netcdf.getVar(ncid,varid);
 varid  = netcdf.inqVarID(ncid,'upSol_mm_s3_TOA');
@@ -65,24 +65,15 @@ netcdf.close(ncid);
 downSol_srf = downSol_srf';
 upSol_TOA = upSol_TOA';
 downSol_TOA = downSol_TOA';
-
+%
 % calculate upSol_srf (reflected from surface)
 upSol_srf = gi_albd_surface.*downSol_srf;
 % calculate diff between TOA outgoing solar and surface-reflected 
-% outgoing solar to obtain cloud-reflected outgoing solar energy
+% outgoing solar to obtain cloud-reflected fraction of outgoing solar energy
 upSol_Cloud = upSol_TOA - upSol_srf;
 % calculate cloud albedo and 
 gi_albd_cloud = (upSol_Cloud./downSol_TOA);
-
-
-% % load
-% downSol_mm_TOA=ncread([str_path '/' str(1).nc '.nc'],'downSol_mm_TOA');
-% downSol_Seaice_mm_s3_srf=ncread([str_path '/' str(1).nc '.nc'],'downSol_Seaice_mm_s3_srf');
-% 
-% %transpose
-% downSol_mm_TOA=downSol_mm_TOA';
-% downSol_Seaice_mm_s3_srf=downSol_Seaice_mm_s3_srf';
-
+%
 %
 % *********************************************************************** %
 

--- a/source/fun_read_imask_hadcm3x.m
+++ b/source/fun_read_imask_hadcm3x.m
@@ -18,18 +18,36 @@ function [mask] = fun_read_imask_hadcm3x(str)
 % str(6).nc == par_nc_ocean_name
 % str(7).nc == par_nc_biome_name
 %
-% open netCDF file
-ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(7).nc '.nc'],'nowrite');
-% load ICE MASK
-varid  = netcdf.inqVarID(ncid,'icemask');
-mask(:,:) = netcdf.getVar(ncid,varid);
-mask = double(mask);
+% check if icemask input file exists
+if exist([str(1).path '/' str(1).exp '/' str(7).nc '.nc']) ~= 0
+    % open netCDF file
+    ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(7).nc '.nc'],'nowrite');
+    % load ICE MASK
+    varid  = netcdf.inqVarID(ncid,'icemask');
+    mask(:,:) = netcdf.getVar(ncid,varid);
+    mask = double(mask);
+    % close netCDF file
+    netcdf.close(ncid);
+else
+    % if file does not exist, assume no ice
+    disp(['         WARNING: icemask input file not found. Assume no icesheets']);
+    % open different netCDF to get grid specification
+    ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(4).nc '.nc'],'nowrite');
+    % load land-sea mask
+    varid  = netcdf.inqVarID(ncid,'lsm');
+    mask(:,:) = netcdf.getVar(ncid,varid);
+    mask = double(mask);
+    % assign all zeros (assume no ice)
+    mask = mask.*0;
+    % close netCDF file
+    netcdf.close(ncid);
+end
+%
 % NOTE: format needed is: [LAT,LON] (rows x columns) orientation
 %       => flip up-down & transpose to give a readable ASCII array
 % NOTE: for some reason this field does not need flipud-ing ... ??
 mask = mask';
-% close netCDF file
-netcdf.close(ncid);
+%
 %
 % *********************************************************************** %
 

--- a/source/fun_read_imask_hadcm3x.m
+++ b/source/fun_read_imask_hadcm3x.m
@@ -30,7 +30,7 @@ if exist([str(1).path '/' str(1).exp '/' str(7).nc '.nc']) ~= 0
     netcdf.close(ncid);
 else
     % if file does not exist, assume no ice
-    disp(['         WARNING: icemask input file not found. Assume no icesheets']);
+    disp(['      *** WARNING *** icemask input file not found. Assume no icesheets']);
     % open different netCDF to get grid specification
     ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(4).nc '.nc'],'nowrite');
     % load land-sea mask

--- a/source/fun_read_orog_foam.m
+++ b/source/fun_read_orog_foam.m
@@ -1,4 +1,4 @@
-function [grid_orog] = fun_read_orog_hadcm3x(str)
+function [grid_orog] = fun_read_orog_foam(str)
 %
 %%
 
@@ -7,31 +7,25 @@ function [grid_orog] = fun_read_orog_hadcm3x(str)
 % *********************************************************************** %
 %
 % open netCDF file and load variables
-% NOTE: add legacy / traceabile variable reading
 %
 % str input KEY:
-% str(1).nc == par_nc_axes_name
-% str(2).nc == par_nc_topo_name
-% str(3).nc == par_nc_atmos_name
-% str(4).nc == par_nc_mask_name
+% str(1).nc == par_nc_axes_name ('topo')
+% str(2).nc == par_nc_topo_name ('topo')
+% str(3).nc == par_nc_atmos_name ('atmos')
+% str(4).nc == par_nc_mask_name ('topo')
 % str(5).nc == par_nc_coupl_name
-% str(6).nc == par_nc_ocean_name
-% str(7).nc == par_nc_biome_name
-% str(8).nc == par_nc_orog_name
 %
 % open netCDF file
-ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(8).nc '.nc'],'nowrite');
+ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(2).nc '.nc'],'nowrite');
 % load TOPOGRAPHY
-varid  = netcdf.inqVarID(ncid,'ht');
+varid  = netcdf.inqVarID(ncid,'TOPO');
 grid_orog(:,:) = netcdf.getVar(ncid,varid);
 grid_orog = double(grid_orog);
-% NOTE: format needed is: [LAT,LON] (rows x columns) orientation
-%       => flip up-down & transpose to give a readable ASCII array
-% NOTE: for some reason this field does not need flipud-ing ... ??
-grid_orog = grid_orog';
-% filter out land (mark as invalid)
-% NOTE: assume that zero is ocean, land-sea corrections made in muffingen.m
-grid_orog(find(grid_orog==0.0))=NaN;
+% flip array around diagonal to give (lon,lat) array orientation
+grid_orog = flipud(grid_orog');
+% filter out ocean (mark as invalid)
+% NOTE: assume neg topo is ocean, land-sea corrections made in muffingen.m
+grid_orog(find(grid_orog<0.0))=NaN;
 % close netCDF file
 netcdf.close(ncid);
 %

--- a/source/make_grid_albd.m
+++ b/source/make_grid_albd.m
@@ -10,7 +10,7 @@ function [vo_albd,vo_albd_atm]  = make_grid_albd(go_latm,par_age)
 [jmax] = length(go_latm);
 % create otput vectors
 vo_albd = 0.0*go_latm;
-vo_albd_atm = 0.0*go_latm; 
+vo_albd_atm = 0.0*go_latm;
 % convert rad to deg
 loc_latm = (pi/180.0)*go_latm;
 %
@@ -46,7 +46,9 @@ else
 end
 % calculate the albedo profile itself
 for j = 1:jmax
+    % planetary albedo
     vo_albd(j) = climalbedo_offset + climalbedo_amp*0.5*(1.0 - cos(2.0*loc_latm(j)) + climalbedo_mod*cos(6.0*loc_latm(j)));
+    % atmospheric or 'cloud' albedo
     vo_albd_atm(j) = atmalbedo_offset + atmalbedo_amp*0.5*(1.0 - cos(2.0*loc_latm(j)) + atmalbedo_mod*cos(6.0*loc_latm(j)));
 end
 %

--- a/source/make_grid_albd.m
+++ b/source/make_grid_albd.m
@@ -1,4 +1,4 @@
-function [vo_albd]  = make_grid_albd(go_latm,par_age)
+function [vo_albd,vo_albd_atm]  = make_grid_albd(go_latm,par_age)
 %
 %%
 
@@ -8,9 +8,10 @@ function [vo_albd]  = make_grid_albd(go_latm,par_age)
 %
 % determine output vector size
 [jmax] = length(go_latm);
-% create otput vector
+% create otput vectors
 vo_albd = 0.0*go_latm;
-%
+vo_albd_atm = 0.0*go_latm; 
+% convert rad to deg
 loc_latm = (pi/180.0)*go_latm;
 %
 % *********************************************************************** %
@@ -20,22 +21,33 @@ loc_latm = (pi/180.0)*go_latm;
 % *********************************************************************** %
 %
 % test for modern and set albedo profile parameters
-if (par_age == 0.0),
+if (par_age == 0.0)
     % assume modern
     % NOTE: this is the GENIE modern default
     climalbedo_offset = 0.20;
     climalbedo_amp    = 0.36;
     climalbedo_mod    = 0.0;
+    % PV: include atm albedo
+    % NOTE: this is based off atm_albedo_monthly.dat
+    atmalbedo_offset = 0.17;
+    atmalbedo_amp    = 0.18;
+    atmalbedo_mod    = 0.30;
 else
     % assume ice-free
     % NOTE: this is the Ridgwell and Schmidt [2010] early Eocene profile
     climalbedo_offset = 0.20;
     climalbedo_amp    = 0.26;
     climalbedo_mod    = 0.25;
+    % PV: include atm albedo
+    % NOTE: this is based off HadCM3 timeslice for 55.8 Ma (texfl)
+    atmalbedo_offset = 0.16;
+    atmalbedo_amp    = 0.18;
+    atmalbedo_mod    = 0.36;
 end
 % calculate the albedo profile itself
-for j = 1:jmax,
+for j = 1:jmax
     vo_albd(j) = climalbedo_offset + climalbedo_amp*0.5*(1.0 - cos(2.0*loc_latm(j)) + climalbedo_mod*cos(6.0*loc_latm(j)));
+    vo_albd_atm(j) = atmalbedo_offset + atmalbedo_amp*0.5*(1.0 - cos(2.0*loc_latm(j)) + atmalbedo_mod*cos(6.0*loc_latm(j)));
 end
 %
 % *********************************************************************** %

--- a/source/make_grid_albd_all.m
+++ b/source/make_grid_albd_all.m
@@ -1,0 +1,60 @@
+function [vo_albd,vo_albd_atm]  = make_grid_albd_all(go_latm,par_age)
+%
+%%
+
+% *********************************************************************** %
+% *** INITIALIZE PARAMETERS & VARIABLES ********************************* %
+% *********************************************************************** %
+%
+% determine output vector size
+[jmax] = length(go_latm);
+% create otput vector
+vo_albd = 0.0*go_latm;
+% convert rad to deg
+loc_latm = (pi/180.0)*go_latm;
+%
+% *********************************************************************** %
+
+% *********************************************************************** %
+% *** CREATE GENERIC ALBEDO ********************************************* %
+% *********************************************************************** %
+%
+% test for modern and set albedo profile parameters
+if (par_age == 0.0)
+    % assume modern
+    % NOTE: this is the GENIE modern default
+    climalbedo_offset = 0.20;
+    climalbedo_amp    = 0.36;
+    climalbedo_mod    = 0.0;
+    % PV: include atm albedo
+    % NOTE: this is based off atm_albedo_monthly.dat
+    atmalbedo_offset = 0.17;
+    atmalbedo_amp    = 0.18;
+    atmalbedo_mod    = 0.30;
+else
+    % assume ice-free
+    % NOTE: this is the Ridgwell and Schmidt [2010] early Eocene profile
+    climalbedo_offset = 0.20;
+    climalbedo_amp    = 0.26;
+    climalbedo_mod    = 0.25;
+    % PV: include atm albedo
+    % NOTE: this is based off HadCM3 timeslice for 55.8 Ma (texfl)
+    atmalbedo_offset = 0.16;
+    atmalbedo_amp    = 0.18;
+    atmalbedo_mod    = 0.36;
+end
+% calculate the albedo profile itself
+for j = 1:jmax
+    vo_albd(j) = climalbedo_offset + climalbedo_amp*0.5*(1.0 - cos(2.0*loc_latm(j)) + climalbedo_mod*cos(6.0*loc_latm(j)));
+    vo_albd_atm(j) = atmalbedo_offset + atmalbedo_amp*0.5*(1.0 - cos(2.0*loc_latm(j)) + atmalbedo_mod*cos(6.0*loc_latm(j)));
+end
+%
+% *********************************************************************** %
+
+% *********************************************************************** %
+% *** END *************************************************************** %
+% *********************************************************************** %
+%
+%%%
+%
+% *********************************************************************** %

--- a/source/make_grid_winds_hadcm3x.m
+++ b/source/make_grid_winds_hadcm3x.m
@@ -1,4 +1,4 @@
-function [] = make_grid_winds_hadcm3x(giloncm,gilonce,gilatcm,gilatce,gilonpm,gilonpe,gilatpm,gilatpe,gimask,golonm,golone,golatm,golate,gomask,str,optplots);
+function [] = make_grid_winds_hadcm3x(giloncm,gilonce,gilatcm,gilatce,gilonpm,gilonpe,gilatpm,gilatpe,gimask,golonm,golone,golatm,golate,gomask,str,optplots)
 % make_grid_winds_hadcm3
 %
 %   *********************************************************
@@ -70,31 +70,44 @@ ncid = netcdf.open([str(1).path '/' str(1).exp '/' str(5).nc '.nc'],'nowrite');
 % t grid == all wind products
 %        -> edges are: gilonm,gilatm
 %
-% load TAUX
+% load TAUX - windstress
 varid  = netcdf.inqVarID(ncid,'taux_mm_hyb');
 loctau(:,:) = netcdf.getVar(ncid,varid);
 giwtauu = double(loctau');
-% load TAUY
+% load TAUY - windstress
 varid  = netcdf.inqVarID(ncid,'tauy_mm_hyb');
 loctau(:,:) = netcdf.getVar(ncid,varid);
 giwtauv = double(loctau');
-% load U
+% load U - wind velocity
 varid  = netcdf.inqVarID(ncid,'u_mm_10m');
 locwvel(:,:) = netcdf.getVar(ncid,varid);
 giwvelu = double(locwvel');
-% load V
+% load V - wind velocity
 varid  = netcdf.inqVarID(ncid,'v_mm_10m');
 locwvel(:,:) = netcdf.getVar(ncid,varid);
 giwvelv = double(locwvel');
 %
 % *** process data -- wind speed **************************************** %
 %
-%         % load wind speed scalar
-%         varid  = netcdf.inqVarID(ncid,'wind_mm_10m');
-%         old_wspd(:,:) = netcdf.getVar(ncid,varid);
-%         new_wspd = double(old_wspd);
-%         wspd = maskv.*flipdim(new_wspd',1);
-% calculate wind speed
+% assume windspeed varaible exists in netCDF
+str_windmm_exist = 'yes';
+% check if windspeed variable exists in netCDF
+try
+    varid = netcdf.inqVarID(ncid,'wind_mm_10m');
+catch exception
+    if strcmp(exception.identifier,'MATLAB:imagesci:netcdf:libraryFailure')
+        fprintf('       - windspeed variable (wind_mm_10m) does not exists in .nc\n');
+        str_windmm_exist = 'no';
+    end
+end
+% extract windspeed if exists
+if strcmp(str_windmm_exist,'yes')
+    varid = netcdf.inqVarID(ncid,'wind_mm_10m');
+    locwspd(:,:) = netcdf.getVar(ncid,varid);
+    % get windspeeds directly from GCM windspeed output
+    giwspd_wsma = double(locwspd');
+end
+% calculate wind speed from velocity
 giwspd_uvaa = (giwvelu.^2 + giwvelv.^2).^0.5;
 %
 % *** close netCDF file ************************************************* %
@@ -112,7 +125,11 @@ fprintf('       - Creating wind product input mask\n');
 % create ocean (only) mask -- c grid
 gimaskc = gimask;
 gimaskc(find(gimaskc == 0)) = NaN;
-% create ocean (only) mask -- p grid
+% create land (only) mask -- c grid
+gimaskcl = gimask;
+gimaskcl(find(gimaskcl == 1)) = NaN;
+gimaskcl(find(gimaskcl == 0)) = 1;
+% create masks -- p grid
 % NOTE: edges are: gilonm,gilatm
 % *assumption* :: ALL p-grid points surrounding an invalid c-grid point
 %                 are also invalid
@@ -124,6 +141,7 @@ n_latc = length(gilatcm);
 n_lonp = length(gilonpm);
 n_latp = length(gilatpm);
 %
+% create ocean (only) mask -- p grid
 gimaskp = zeros(n_latp,n_lonp);
 gimaskp = gimaskp + 1;
 %
@@ -157,7 +175,7 @@ if isnan(gimaskc(latc,lonc)),
     gimaskp(latc-1,n_lonc) = NaN;
     gimaskp(latc-1,lonc) = NaN;
 end
-% then -- all remaining longitude points
+% then -- all remaining longitude points 
 for lonc=2:n_lonc,
     latc = 1;
     if isnan(gimaskc(latc,lonc)),
@@ -182,6 +200,15 @@ end
 if (optplots), plot_2dgridded(flipud(gimaskc),999.0,'',[[str(2).dir '/' str(2).exp] '.maskc.IN'],['c-grid mask']); end
 if (optplots), plot_2dgridded(flipud(gimaskp),999.0,'',[[str(2).dir '/' str(2).exp] '.maskp.IN'],['p-grid mask']); end
 %
+% make land grid
+gimaskpl = gimaskp;
+gimaskpl(gimaskpl==1) = 0;
+gimaskpl(isnan(gimaskpl)) = 1;
+gimaskpl(gimaskpl==0) = NaN;
+%
+if (optplots), plot_2dgridded(flipud(gimaskcl),999.0,'',[[str(2).dir '/' str(2).exp] '.maskcl.IN'],['c-grid landmask']); end
+if (optplots), plot_2dgridded(flipud(gimaskpl),999.0,'',[[str(2).dir '/' str(2).exp] '.maskpl.IN'],['p-grid landmask']); end
+%
 % *********************************************************************** %
 
 % *********************************************************************** %
@@ -200,7 +227,7 @@ if (optplots), plot_2dgridded(flipud(gimaskp),999.0,'',[[str(2).dir '/' str(2).e
 %   ---------
 % 
 % remember: [rows columns] == [j i]
-% grid doudaries are as follows:
+% grid boundaries are as follows:
 % GENIE c-grid: (golate,golone)   == jmax+1 x imax+1
 % GENIE u-grid: (golatue,golonue) == jmax   x imax+1
 % GENIE v-grid: (golatve,golonve) == jmax+1 x imax
@@ -212,9 +239,13 @@ golatve = [golatm 90.0];
 % longitude
 golonue = [golonm golonm(end)+360.0/imax];
 golonve = golone;
-% create GENIE NaN mask
+% create GENIE NaN mask -- ocean
 gm = gomask;
 gm(find(gm == 0)) = NaN;
+% create GENIE NaN mask -- land
+gml = gomask;
+gml(find(gml == 1)) = NaN;
+gml(find(gml == 0)) = 1;
 %
 % *** Put on a GOLDSTEIN grid ******************************************* %
 %
@@ -293,14 +324,14 @@ if (optplots), plot_2dgridded(flipud(gowvelv),999.0,'',[[str(2).dir '/' str(2).e
 % replace NaNs with zeros
 % apply GENIE mask to output wind speed
 fprintf('       - Regridding wind speed to GOLDSTEIN c-grid\n');
-% wspeed_uvaa
-if (optplots), plot_2dgridded(flipud(giwspd_uvaa),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd.IN'],['wind speed in']); end
+% wspeed_uvaa (derived from velocity)
+if (optplots), plot_2dgridded(flipud(giwspd_uvaa),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_uvaa.IN'],['wind speed in']); end
 % re-grid complete field
 [gowspdall,gofwspdall] = make_regrid_2d(gilonpe,gilatpe,giwspd_uvaa',golone,golate,false);
 gowspdall = gowspdall';
 gofwspdall = gofwspdall';
 if (optplots), plot_2dgridded(flipud(gowspdall),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_uvaa.OUTALL'],['wind speed out -- without mask']); end
-% re-grid masked field
+% re-grid masked field (ocean only)
 [gowspd,gofwspd] = make_regrid_2d(gilonpe,gilatpe,(gimaskp.*giwspd_uvaa)',golone,golate,false);
 gowspd = gowspd';
 gofwspd = gofwspd';
@@ -308,9 +339,60 @@ wspeed_uvaa = gomask.*gowspd;
 wspeed_uvaa(find(isnan(wspeed_uvaa))) = 0.0;
 if (optplots), plot_2dgridded(flipud(gm.*wspeed_uvaa),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_uvaa.OUT'],['wind speed out -- with mask']); end
 %
+if strcmp(str_windmm_exist,'yes')
+    % wspeed_wsma (derived directly from windspeed)
+    if (optplots), plot_2dgridded(flipud(giwspd_wsma),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_wsma.IN'],['wind speed in']); end
+    % re-grid complete field
+    [gowspdall_wsma,gofwspdall_wsma] = make_regrid_2d(gilonpe,gilatpe,giwspd_wsma',golone,golate,false);
+    gowspdall_wsma = gowspdall_wsma';
+    gofwspdall_wsma = gofwspdall_wsma';
+    if (optplots), plot_2dgridded(flipud(gowspdall_wsma),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_wsma.OUTALL'],['wind speed out -- without mask']); end
+    % re-grid masked field (ocean only)
+    [gowspd_wsma,gofwspd_wsma] = make_regrid_2d(gilonpe,gilatpe,(gimaskp.*giwspd_wsma)',golone,golate,false);
+    gowspd_wsma = gowspd_wsma';
+    gofwspd_wsma = gofwspd_wsma';
+    wspeed_wsma = gomask.*gowspd_wsma;
+    wspeed_wsma(find(isnan(wspeed_wsma))) = 0.0;
+    if (optplots), plot_2dgridded(flipud(gm.*wspeed_wsma),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_wsma.OUT'],['wind speed out -- with mask']); end
+end
+%
+% *** Put on a ENTS (land) grid ******************************************* %
+%
+% NOTE: don't forget to flip the re-gridded orientation back around again
+%
+% make GENIE land mask
+glmask = abs(gomask-1);
+%
+% -> wind speed
+% NOTE: GENIE c-grid: (golate,golone) == jmax+1 x imax+1
+% create output grids with and without the (p-grid) mask applied to
+% the input wind speed grid for land
+% replace NaNs with zeros
+% apply GENIE mask (land) to output wind speed
+fprintf('       - Regridding wind speed to land c-grid\n');
+% uvaa (velocity derived speed)
+% re-grid masked field (land only)
+[gowspdl,gofwspdl] = make_regrid_2d(gilonpe,gilatpe,(gimaskpl.*giwspd_uvaa)',golone,golate,false);
+gowspdl = gowspdl';
+gofwspdl = gofwspdl';
+wspeed_uvaal = glmask.*gowspdl;
+wspeed_uvaal(find(isnan(wspeed_uvaal))) = 0.0;
+if (optplots), plot_2dgridded(flipud(gml.*wspeed_uvaal),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_uvaal.OUT'],['wind speed out -- with mask']); end
+%
+if strcmp(str_windmm_exist,'yes')
+    % wsma (windspeed derived speed)
+    % re-grid masked field (land only)
+    [gowspdl_wsmal,gofwspdl_wsmal] = make_regrid_2d(gilonpe,gilatpe,(gimaskpl.*giwspd_wsma)',golone,golate,false);
+    gowspdl_wsmal = gowspdl_wsmal';
+    gofwspdl_wsmal = gofwspdl_wsmal';
+    wspeed_wsmal = glmask.*gowspdl_wsmal;
+    wspeed_wsmal(find(isnan(wspeed_wsmal))) = 0.0;
+    if (optplots), plot_2dgridded(flipud(gml.*wspeed_wsmal),999.0,'',[[str(2).dir '/' str(2).exp] '.wspd_wsmal.OUT'],['wind speed out -- with mask']); end
+end
+%
 % *** Copy to output arrays ********************************************* %
 %
-% -> wind stress
+% -> wind stress - GOLDSTEIN
 wstress(:,:,1) = flipud(gowtauuu); %g_taux_u
 wstress(:,:,2) = flipud(gowtauuv); %g_taux_v
 wstress(:,:,3) = flipud(gowtauvu); %g_tauy_u
@@ -325,49 +407,81 @@ wvelocity(:,:,2) = flipud(gowvelv);
 % *** SAVE DATA ********************************************************* %
 % *********************************************************************** %
 %
-% Save regridded data to file
+% Save regridded data to file OCEAN-only
 % Taux at u point (g_taux_u == gowtauuu)
 outname = [str(2).dir '/' str(2).exp '.taux_u.dat'];
 c = wstress(:,:,1); b = permute(c, [2 1]); a = reshape(b, [imax*jmax 1]);
 save (outname, 'a', '-ascii');
-fprintf('       - Written tau u (u point) data to %s\n',outname);
+fprintf('       - Written tau u (u point) data\n');
 % Taux at v point (g_taux_v == gowtauuv)
 outname = [str(2).dir '/' str(2).exp '.taux_v.dat'];
 c = wstress(:,:,2); b = permute(c, [2 1]); a = reshape(b, [imax*jmax 1]);
 save (outname, 'a', '-ascii');
-fprintf('       - Written tau u (v point) data to %s\n',outname);
+fprintf('       - Written tau u (v point) data\n');
 % Tauy at u point (g_tauy_u == gowtauvu)
 outname = [str(2).dir '/' str(2).exp '.tauy_u.dat'];
 c = wstress(:,:,3); b = permute(c, [2 1]); a = reshape(b, [imax*jmax 1]);
 save (outname, 'a', '-ascii');
-fprintf('       - Written tau v (u point) data to %s\n',outname);
+fprintf('       - Written tau v (u point) data\n');
 % Tauy at v point (g_tauy_v == gowtauvv)
 outname = [str(2).dir '/' str(2).exp '.tauy_v.dat'];
 c = wstress(:,:,4); b = permute(c, [2 1]); a = reshape(b, [imax*jmax 1]);
 save (outname, 'a', '-ascii');
-fprintf('       - Written tau v (v point) data to %s\n',outname);
+fprintf('       - Written tau v (v point) data\n');
 %
 % X wind velocity 
 outname = [str(2).dir '/' str(2).exp '.wvelx.dat'];
 c = wvelocity(:,:,1); b = permute(c, [2 1]); a = reshape(b, [imax*jmax 1]);
 save (outname, 'a', '-ascii');
-fprintf('       - Written u wind speed data to %s\n',outname);
+fprintf('       - Written u wind velocity data\n');
 % Y wind speed
 outname = [str(2).dir '/' str(2).exp '.wvely.dat'];
 c = wvelocity(:,:,2); b = permute(c, [2 1]); a = reshape(b, [imax*jmax 1]);
 save (outname, 'a', '-ascii');
-fprintf('       - Written v wind speed data to %s\n',outname);
+fprintf('       - Written v wind velocity data\n');
+%
 % Save 2-D ASCII wind speed scalar for BIOGEM
 outname = [str(2).dir '/' str(2).exp '.windspeed_uvaa.dat'];
 a = wspeed_uvaa;
 save(outname,'a','-ascii');
-% outname = [str(2).dir '/' str(2).exp '.windspeed_uvma.dat'];
-% a = wspeed_uvma;
-% save(outname,'a','-ascii');
-% outname = [str(2).dir '/' str(2).exp '.windspeed_wsma.dat'];
-% a = wspeed_wsma;
-% save(outname,'a','-ascii');
-fprintf('       - Written BIOGEM windspeed data to %s\n',outname);
+fprintf('       - Written BIOGEM windspeed data\n');
+% Save 2-D ASCII wind speed scalar on FULL grid 
+%   no seperation between land-ocean while regridding
+%   uvaa velocity dereived windspeed field
+wspeed_all = gowspdall;
+outname = [str(2).dir '/' str(2).exp '.windspeed_uvaa_all.dat'];
+a = wspeed_all;
+save(outname,'a','-ascii');
+fprintf('       - Written FULL GRID uvaa windspeed data\n');
+% Save 2-D ASCII wind speed scalar on ocean + land grids
+%   only consider GCM ocean grids for cGENIE ocean windspeed
+%   only consider GCM land grids for cGENIE land windspeed
+wspeed_ents = wspeed_uvaa+wspeed_uvaal; % combine ocean+land
+outname = [str(2).dir '/' str(2).exp '.windspeed_uvaa_ents.dat'];
+a = wspeed_ents;
+save(outname,'a','-ascii');
+fprintf('       - Written ENTS uvaa windspeed (derived from velocity)\n');
+%
+if strcmp(str_windmm_exist,'yes')
+    % Save 2-D ASCII wind speed scalar on FULL grid
+    %   no seperation between land-ocean while regridding
+    %   wsma windspeed derived windspeed field
+    wspeed_all_wsma = gowspdall_wsma;
+    outname = [str(2).dir '/' str(2).exp '.windspeed_wsma_all.dat'];
+    a = wspeed_all_wsma;
+    save(outname,'a','-ascii');
+    fprintf('       - Written FULL GRID wsma windspeed data\n');
+    % Save 2-D ASCII wind speed scalar on ocean + land grids
+    %   only consider GCM ocean grids for cGENIE ocean windspeed
+    %   only consider GCM land grids for cGENIE land windspeed
+    wspeed_ents = wspeed_wsma+wspeed_wsmal; % combine ocean+land
+    outname = [str(2).dir '/' str(2).exp '.windspeed_wsma_ents.dat'];
+    a = wspeed_ents;
+    save(outname,'a','-ascii');
+    fprintf('       - Written ENTS uvaa windspeed (derived from windspeed)\n');
+end
+
+end
 %
 % *********************************************************************** %
 


### PR DESCRIPTION
Options added for HadCM3, FOAM, and 'fake worlds' to generate regridded fields for usage with ENTS. These include:
- icemask
- orography 
- atmospheric albedo
- full-grid windspeed